### PR TITLE
DPI-2921 Package rhtmlHeatmap in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "rhtmlHeatmap";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''An improved heatmap package based on d3heatmap.'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    htmlwidgets
+    base64enc
+    png
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package rhtmlHeatmap in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR