### PR TITLE
DPI-2932 Package rhtmlHeatmap in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -6,8 +6,8 @@ pkgs.rPackages.buildRPackage {
   src = ./.;
   description = ''An improved heatmap package based on d3heatmap.'';
   propagatedBuildInputs = with pkgs.rPackages; [ 
+    png
     htmlwidgets
     base64enc
-    png
   ];
 }


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package rhtmlHeatmap in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR